### PR TITLE
Version 2.1.1

### DIFF
--- a/blender/__init__.py
+++ b/blender/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "Sonic Adventure I/O",
     "author": "Justin113D, ItsEasyActually, X-Hax",
     "description": "Import/Exporter for Sonic Adventure Model, Animation and other Formats.",
-    "version": (2, 1, 0),
+    "version": (2, 1, 1),
     "blender": (4, 0, 0),
     "location": "",
     "warning": "",

--- a/blender/__initdev__.py
+++ b/blender/__initdev__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "Sonic Adventure I/O TEST BUILD",
     "author": "Justin113D, ItsEasyActually, X-Hax",
     "description": "Import/Exporter for Sonic Adventure Model, Animation and other Formats.",
-    "version": (2, 1, 0),
+    "version": (2, 1, 1),
     "blender": (4, 0, 0),
     "location": "",
     "warning": "",

--- a/blender/source/exporting/o_enum.py
+++ b/blender/source/exporting/o_enum.py
@@ -7,9 +7,10 @@ from ..utility.enum_lut import (
     GC_TEXCOORD_SOURCE,
     GC_TEXCOORD_MATRIX,
     ATTACH_FORMAT,
-    MODEL_FORMAT
+    MODEL_FORMAT,
+    EVENT_TYPE
 )
-from ..dotnet import SAIO_NET, SA3D_Modeling
+from ..dotnet import SAIO_NET, SA3D_Modeling, SA3D_SA2Event
 
 
 def to_node_attributes(node_properties):
@@ -80,3 +81,6 @@ def to_attach_format(attach_format: str):
 
 def to_model_format(model_format: str):
     return getattr(SA3D_Modeling.MODEL_FORMAT, MODEL_FORMAT[model_format])
+
+def to_event_type(event_type: str):
+    return getattr(SA3D_SA2Event.EVENT_TYPE, EVENT_TYPE[event_type])

--- a/blender/source/exporting/o_event.py
+++ b/blender/source/exporting/o_event.py
@@ -158,7 +158,7 @@ class EventExporter:
 
             self.entry_source_scene[obj] = self.base_scene
 
-        self.shared_entries.sort(key=lambda x: x.name)
+        self.shared_entries.sort(key=lambda x: x.name.lower())
 
         event_properties = self.base_scene.saio_scene.event
         for name in OVERLAY_UPGRADE_LUT.values():
@@ -207,8 +207,8 @@ class EventExporter:
                 if obj not in self.entry_source_scene:
                     self.entry_source_scene[obj] = cutinfo.scene
 
-            cutinfo.entries.sort(key=lambda x: x.name)
-            cutinfo.particles.sort(key=lambda x: x.name)
+            cutinfo.entries.sort(key=lambda x: x.name.lower())
+            cutinfo.particles.sort(key=lambda x: x.name.lower())
 
         if len(self.blare) > 64:
             raise UserException("Can't have more than 64 blare models!")

--- a/blender/source/exporting/o_event.py
+++ b/blender/source/exporting/o_event.py
@@ -629,6 +629,7 @@ class EventExporter:
             motion = None
             if obj in cutinfo.motions:
                 motion = cutinfo.motions[obj]
+            motion.EnsureKeyframes(posrot)
             result.ParticleMotions.Add(motion)
 
         return result

--- a/blender/source/exporting/o_event.py
+++ b/blender/source/exporting/o_event.py
@@ -207,6 +207,9 @@ class EventExporter:
                 if obj not in self.entry_source_scene:
                     self.entry_source_scene[obj] = cutinfo.scene
 
+            cutinfo.entries.sort(key=lambda x: x.name)
+            cutinfo.particles.sort(key=lambda x: x.name)
+
         if len(self.blare) > 64:
             raise UserException("Can't have more than 64 blare models!")
 
@@ -268,11 +271,10 @@ class EventExporter:
             self.uv_animated_objects.extend(uv_meshes)
 
     def _convert_models(self):
-        base_entries = []
-        base_entries.extend(self.shared_entries)
-        base_entries.extend(self.shadows)
-        base_entries.extend(self.upgrades)
-        base_entries = set(base_entries)
+        base_entries = set()
+        base_entries.update(self.shared_entries)
+        base_entries.update(self.shadows)
+        base_entries.update(self.upgrades)
 
         for entry in base_entries:
             self._convert_model(entry)

--- a/blender/source/exporting/o_event.py
+++ b/blender/source/exporting/o_event.py
@@ -1,6 +1,7 @@
 import bpy
 from bpy.types import Object as BObject
 
+from . import o_enum
 from .o_event_cutinfo import CutInfo
 from .o_shapemotion import ShapeMotionEvaluator
 from .o_model import ModelEvaluator, ModelData
@@ -46,6 +47,7 @@ def get_base_scene(context: bpy.types.Context):
 class EventExporter:
 
     context: bpy.types.Context
+    event_type: str
     optimize: bool
     anim_parameters: AnimParameters
 
@@ -75,11 +77,13 @@ class EventExporter:
     def __init__(
             self,
             context: bpy.types.Context,
+            event_type: str,
             optimize: bool,
             auto_node_attributes: bool,
             anim_parameters: AnimParameters):
 
         self.context = context
+        self.event_type = event_type
         self.optimize = optimize
         self.anim_parameters = anim_parameters
 
@@ -630,7 +634,7 @@ class EventExporter:
         return result
 
     def _setup_eventdata(self):
-        self.event_data = SA3D_SA2Event.MODEL_DATA(SA3D_SA2Event.EVENT_TYPE.gc)
+        self.event_data = SA3D_SA2Event.MODEL_DATA(o_enum.to_event_type(self.event_type))
         self.event_data.EnableDropShadows = \
             self.base_scene.saio_scene.event.drop_shadow_control
 

--- a/blender/source/exporting/o_event_cutinfo.py
+++ b/blender/source/exporting/o_event_cutinfo.py
@@ -169,7 +169,7 @@ class CutInfo:
             self,
             action: bpy.types.Action,
             obj: BObject,
-            only_location: bool = False):
+            no_scale: bool = False):
 
         def create_curve(field, length):
             for i in range(length):
@@ -181,15 +181,14 @@ class CutInfo:
 
         create_curve("location", 3)
 
-        if only_location:
-            return
-
-        create_curve("scale", 3)
-
         if obj.rotation_mode == 'QUATERNION':
             create_curve("rotation_quaternion", 4)
         else:
             create_curve("rotation_euler", 3)
+
+        if not no_scale:
+            create_curve("scale", 3)
+
 
     def _setup_temp_target_action(self, action: bpy.types.Action, obj):
 
@@ -324,7 +323,7 @@ class CutInfo:
             action = self._setup_action(
                 particle.animation_data,
                 particle.name,
-                lambda x: self._setup_temp_object_action(x, particle, True))
+                lambda x: self._setup_temp_object_action(x, particle))
 
             if action is not None:
                 self.output_actions[particle] = action

--- a/blender/source/exporting/o_landtable.py
+++ b/blender/source/exporting/o_landtable.py
@@ -195,10 +195,10 @@ class LandtableEvaluator:
             self._optimize,
             self._write_specular,
             self._apply_modifs,
-            False, # apply posing
+            False,  # Dont apply posing
             self._automatic_node_attributes,
             self._force_sort_bones,
-            False) # flip vertex colors
+            False)  # Dont flip vertex colors
 
         modeldata = evaluator.evaluate(objects)
 
@@ -233,10 +233,10 @@ class LandtableEvaluator:
         self._setup()
         self._organize_objects(objects)
 
-        for objects in self._anim_objects:
-            self._eval_animated(objects)
+        for anim_tree in self._anim_objects:
+            self._eval_animated(anim_tree)
 
-        for obj in self._le_objects:
+        for obj in sorted(self._le_objects, key=lambda x: x.name.lower()):
             if obj.type == 'MESH' and len(obj.data.polygons) > 0:
                 self._eval_entry(obj)
 

--- a/blender/source/exporting/o_model.py
+++ b/blender/source/exporting/o_model.py
@@ -92,7 +92,7 @@ class ModelEvaluator:
             apply_pose: bool = False,
             automatic_node_attributes: bool = True,
             force_sort_bones: bool = False,
-            flip_vertex_color_channels: bool = False,):
+            flip_vertex_color_channels: bool = False):
 
         self._context = context
         self._attach_format = attach_format

--- a/blender/source/exporting/o_node.py
+++ b/blender/source/exporting/o_node.py
@@ -239,9 +239,9 @@ class NodeEvaluator:
                 self._hierarchy_dictionary[obj] = []
 
         for hierarchy_objects in self._hierarchy_dictionary.values():
-            hierarchy_objects.sort(key=lambda x: x.name)
+            hierarchy_objects.sort(key=lambda x: x.name.lower())
 
-        self._parentless.sort(key=lambda x: x.name)
+        self._parentless.sort(key=lambda x: x.name.lower())
 
     def _eval_object(self, obj: BObject, parent_index: int):
 
@@ -261,7 +261,7 @@ class NodeEvaluator:
         children = list(bone.children)
 
         if self._force_sort_bones:
-            children.sort(key=lambda x: x.name)
+            children.sort(key=lambda x: x.name.lower())
 
         for child in children:
             self._eval_bone(child, index)

--- a/blender/source/importing/i_texture.py
+++ b/blender/source/importing/i_texture.py
@@ -15,7 +15,7 @@ def process_texture_set(texture_set, texture_list):
         img.pack()
 
         tex = texture_list.new(name=texture.Name, image=img)
-        tex.global_index = texture.GlobalIndex
+        tex.global_index = SAIO_NET.TEXTURE.ToSigned(texture.GlobalIndex)
         tex.override_width = texture.OverrideWidth
         tex.override_height = texture.OverrideHeight
 

--- a/blender/source/register/operators/export_operators.py
+++ b/blender/source/register/operators/export_operators.py
@@ -413,6 +413,19 @@ class SAIO_OT_Export_Event(NodeAnimExportOperator):
 
     show_bone_localspace = False
 
+    event_type: EnumProperty(
+        name="Event Type",
+        description="Type of event to export",
+        items=(
+            ('DCBETA', "Dreamcast Beta", "Event targetting Dreamcast beta builds"),
+            ('DC', "Dreamcast", "Event targetting Dreamcast"),
+            ('DCGC', "Dreamcast-Gamecube",
+                "Event targetting Gamecube (and ports) but with Greamcast formatting"),
+            ('GC', "Gamecube", "Event targetting Gamecube and ports"),
+        ),
+        default='GC'
+    )
+
     optimize: BoolProperty(
         name="Optimize",
         description="Optimize if possible",
@@ -445,6 +458,7 @@ class SAIO_OT_Export_Event(NodeAnimExportOperator):
     )
 
     def draw(self, context: bpy.types.Context):
+        self.layout.prop(self, "event_type")
         self.layout.prop(self, "optimize")
         self.layout.prop(self, "auto_node_attributes")
         self.layout.prop(self, "export_textures")
@@ -459,6 +473,7 @@ class SAIO_OT_Export_Event(NodeAnimExportOperator):
 
         exporter = o_event.EventExporter(
             context,
+            self.event_type,
             self.optimize,
             self.auto_node_attributes,
             anim_parameters)

--- a/blender/source/register/operators/tool_operators.py
+++ b/blender/source/register/operators/tool_operators.py
@@ -315,7 +315,7 @@ class SAIO_OT_ArmatureFromObjects(SAIOBasePopupOperator):
             resultMeshes.append(parent)
 
         children: list[bpy.types.Object] = [child for child in parent.children]
-        children.sort(key=lambda x: x.name)
+        children.sort(key=lambda x: x.name.lower())
 
         for child in children:
             SAIO_OT_ArmatureFromObjects.add_children(

--- a/blender/source/register/property_groups/texture_properties.py
+++ b/blender/source/register/property_groups/texture_properties.py
@@ -28,8 +28,7 @@ class SAIO_Texture(bpy.types.PropertyGroup):
     global_index: IntProperty(
         name="Global Index",
         description="The global texture id in the texture file",
-        default=0,
-        min=0
+        default=0
     )
 
     override_width: IntProperty(

--- a/blender/source/register/ui/material_panel.py
+++ b/blender/source/register/ui/material_panel.py
@@ -144,8 +144,8 @@ class SAIO_PT_Material(PropertiesPanel):
         rendering_menu.separator(factor=2)
 
         rendering_prop("Double Sided:", "double_sided")
+        rendering_prop("Ignore Lighting:", "ignore_diffuse")
         rendering_prop("Ignore Ambient Lighting:", "ignore_ambient")
-        rendering_prop("Ignore Diffuse Lighting:", "ignore_diffuse")
         rendering_prop("Ignore Specular Lighting:", "ignore_specular")
         rendering_prop("Flat Shading:", "flat_shading")
 

--- a/blender/source/utility/bone_utils.py
+++ b/blender/source/utility/bone_utils.py
@@ -14,7 +14,7 @@ def _get_bone(
 
     children = list(bone.children)
     if force_sort:
-        children.sort(key=lambda b: b.name)
+        children.sort(key=lambda b: b.name.lower())
     for b in children:
         _get_bone(b, force_sort, shape, result)
 

--- a/blender/source/utility/enum_lut.py
+++ b/blender/source/utility/enum_lut.py
@@ -377,3 +377,17 @@ MODEL_FORMAT = {
     'SA2': 'SA2',
     'SA2B': 'SA2B'
 }
+
+EVENT_TYPE = {
+    "dcbeta": "DCBETA",
+    "DCBETA" : "dcbeta",
+
+    "dc": "DC",
+    "DC" : "dc",
+
+    "dcgc": "DCGC",
+    "DCGC" : "dcgc",
+
+    "gc": "GC",
+    "GC" : "gc"
+}

--- a/blender/source/utility/material_setup.py
+++ b/blender/source/utility/material_setup.py
@@ -444,7 +444,7 @@ def assemble_texture_list(
     texlist = world.saio_texture_list
 
     texs = list(texs)
-    texs.sort(key=lambda x: x.name)
+    texs.sort(key=lambda x: x.name.lower())
     index = global_index_offset
     for tex in texs:
         item = texlist.new(image=tex)

--- a/dotnet/Model.cs
+++ b/dotnet/Model.cs
@@ -143,16 +143,19 @@ namespace SAIO.NET
                     meshes = WeightedMesh.MergeAtRoots(meshes);
                 }
 
-                foreach(WeightedMesh mesh in meshes)
+                if(flipVertexColors)
                 {
-                    foreach(BufferCorner[] corners in mesh.TriangleSets)
+                    foreach(WeightedMesh mesh in meshes)
                     {
-                        for(int i = 0; i < corners.Length; i++)
+                        foreach(BufferCorner[] corners in mesh.TriangleSets)
                         {
-                            Color color = corners[i].Color;
-                            (color.Alpha, color.Blue) = (color.Blue, color.Alpha);
-                            (color.Red, color.Green) = (color.Green, color.Red);
-                            corners[i].Color = color;
+                            for(int i = 0; i < corners.Length; i++)
+                            {
+                                Color color = corners[i].Color;
+                                (color.Alpha, color.Blue) = (color.Blue, color.Alpha);
+                                (color.Red, color.Green) = (color.Green, color.Red);
+                                corners[i].Color = color;
+                            }
                         }
                     }
                 }

--- a/dotnet/SAIO.NET.csproj
+++ b/dotnet/SAIO.NET.csproj
@@ -12,12 +12,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="TextCopy" Version="6.2.1" />
-		<PackageReference Include="SA3D.Common" Version="1.4.4" />
-		<PackageReference Include="SA3D.Texturing" Version="1.3.5" />
-		<PackageReference Include="SA3D.Archival" Version="1.1.0" />
-		<PackageReference Include="SA3D.Modeling" Version="1.1.0" />
+		<PackageReference Include="SA3D.Common" Version="1.4.5" />
+		<PackageReference Include="SA3D.Texturing" Version="1.3.6" />
+		<PackageReference Include="SA3D.Archival" Version="1.1.1" />
+		<PackageReference Include="SA3D.Modeling" Version="1.1.1" />
 		<PackageReference Include="SA3D.Modeling.JSON" Version="1.0.1" />
-		<PackageReference Include="SA3D.SA2Event" Version="1.0.2" />
+		<PackageReference Include="SA3D.SA2Event" Version="1.0.3" />
 	</ItemGroup>
 
 </Project>

--- a/dotnet/Texture.cs
+++ b/dotnet/Texture.cs
@@ -27,11 +27,13 @@ namespace SAIO.NET
             return result;
         }
 
-        public static Image Create(string name, uint globalIndex, int width, int height, bool? index4, float[] colors)
+        public static Image Create(string name, int globalIndex, int width, int height, bool? index4, float[] colors)
         {
             ReadOnlySpan<float> source = colors;
             int destIndex = 0;
             int pixRowSize = width * 4;
+
+            uint unsignedGlobalIndex = unchecked((uint)globalIndex);
 
             if(index4 == null)
             {
@@ -47,7 +49,7 @@ namespace SAIO.NET
                     }
                 }
 
-                return new ColorTexture(width, height, pixelData, name, globalIndex);
+                return new ColorTexture(width, height, pixelData, name, unsignedGlobalIndex);
             }
             else
             {
@@ -67,11 +69,16 @@ namespace SAIO.NET
                     }
                 }
 
-                return new IndexTexture(width, height, pixelData, name, globalIndex)
+                return new IndexTexture(width, height, pixelData, name, unsignedGlobalIndex)
                 {
                     IsIndex4 = index4.Value
                 };
             }
+        }
+    
+        public static int ToSigned(uint number)
+        {
+            return unchecked((int)number);
         }
     }
 }


### PR DESCRIPTION
## Additions
- Ability to export events for different target systems

## Changes
- material properties "Ignore diffuse lighting" renamed to "Ignore lighting"

## Fixed issues
- Vertex color flipping was always applied on chunk models when importing
- Fixed object sorting all over the addon
- Global texture indices above 0x7FFFFFFF not supported
- Event particle motion should have rotation keyframes
- Event E0100 export crashed the game
- Labels with illegal characters now get corrected
- Fixed various file path issues for Linux
- Animation euler angles were using incorrect BAMS formatting