### PR TITLE
Updater Patches/Fixes

### DIFF
--- a/blender/source/register/addon_updater/addon_updater_ops.py
+++ b/blender/source/register/addon_updater/addon_updater_ops.py
@@ -1408,7 +1408,7 @@ def register(bl_info):
     # update. If a pattern file is not found in new update, no action is taken
     # NOTE: This does NOT delete anything proactively, rather only defines what
     # is allowed to be overwritten during an update execution.
-    updater.overwrite_patterns = ["*.png", "*.jpg", "README.md", "LICENSE.txt"]
+    updater.overwrite_patterns = ["*.dll", "*.json", "*.blend"]
     # updater.overwrite_patterns = []
     # other examples:
     # ["*"] means ALL files/folders will be overwritten by update, was the

--- a/blender/source/register/addon_updater/addon_updater_ops.py
+++ b/blender/source/register/addon_updater/addon_updater_ops.py
@@ -1446,7 +1446,7 @@ def register(bl_info):
     # but the user has the option from user preferences to directly
     # update to the master branch or any other branches specified using
     # the "install {branch}/older version" operator.
-    updater.include_branches = True
+    updater.include_branches = False
 
     # (GitHub only) This options allows using "releases" instead of "tags",
     # which enables pulling down release logs/notes, as well as installs update


### PR DESCRIPTION
Two minor changes to the addon_updater_ops.py file. 

- Fixed the overwrite_patterns variable to use dll, json, and blend so all necessary files are overwritten when updating. This should work in a forward manner meaning users shouldn't need to manually update going forward.
- Set the include_branches variable to False. It allows repo branches to be included as download options, and the addon can only function with release/compiled builds. Should prevent users from accidentally getting a non-built version when updating.