### PR TITLE
Version 2.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sonic Adventure Blender I/O Addon
 
-### Current Minimum Blender Version: 4.0+
+### Current Minimum Blender Version: 4.1+
 
 This addon adds support for the Sonic Adventure formats regarding import, export, animation editing, and additional features.
 

--- a/blender/__init__.py
+++ b/blender/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "Sonic Adventure I/O",
     "author": "Justin113D, ItsEasyActually, X-Hax",
     "description": "Import/Exporter for Sonic Adventure Model, Animation and other Formats.",
-    "version": (2, 1, 4),
+    "version": (2, 1, 5),
     "blender": (4, 0, 0),
     "location": "",
     "warning": "",

--- a/blender/__init__.py
+++ b/blender/__init__.py
@@ -7,7 +7,7 @@ bl_info = {
     "author": "Justin113D, ItsEasyActually, X-Hax",
     "description": "Import/Exporter for Sonic Adventure Model, Animation and other Formats.",
     "version": (2, 1, 5),
-    "blender": (4, 0, 0),
+    "blender": (4, 1, 0),
     "location": "",
     "warning": "",
     "doc_url": "https://x-hax.github.io/SonicAdventureBlenderIO/",

--- a/blender/__initdev__.py
+++ b/blender/__initdev__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "Sonic Adventure I/O TEST BUILD",
     "author": "Justin113D, ItsEasyActually, X-Hax",
     "description": "Import/Exporter for Sonic Adventure Model, Animation and other Formats.",
-    "version": (2, 1, 4),
+    "version": (2, 1, 5),
     "blender": (4, 0, 0),
     "location": "",
     "warning": "",

--- a/blender/__initdev__.py
+++ b/blender/__initdev__.py
@@ -7,7 +7,7 @@ bl_info = {
     "author": "Justin113D, ItsEasyActually, X-Hax",
     "description": "Import/Exporter for Sonic Adventure Model, Animation and other Formats.",
     "version": (2, 1, 5),
-    "blender": (4, 0, 0),
+    "blender": (4, 1, 0),
     "location": "",
     "warning": "",
     "doc_url": "https://x-hax.github.io/SonicAdventureBlenderIO/",

--- a/blender/source/exporting/o_mesh.py
+++ b/blender/source/exporting/o_mesh.py
@@ -84,16 +84,12 @@ class ModelMesh:
                 modifier.show_viewport = False
 
         # add edge split modifier
-        if self.object.data.use_auto_smooth:
-            self._edge_split_modifier = self.object.modifiers.new(
-                "ExportEdgeSplit",
-                'EDGE_SPLIT')
+        self._edge_split_modifier = self.object.modifiers.new(
+            "ExportEdgeSplit",
+            'EDGE_SPLIT')
 
-            self._edge_split_modifier.split_angle \
-                = self.object.data.auto_smooth_angle
-
-            self._edge_split_modifier.use_edge_angle \
-                = not self.object.data.has_custom_normals
+        self._edge_split_modifier.use_edge_angle = False
+        self._edge_split_modifier.use_edge_sharp = True
 
         # add triangulate modifier
         self._triangulate_modifier = self.object.modifiers.new(
@@ -197,13 +193,12 @@ class ModelMesh:
     @staticmethod
     def get_normals(mesh: bpy.types.Mesh):
         normals = [vert.normal for vert in mesh.vertices]
-        if not mesh.use_auto_smooth:
+        if not mesh.has_custom_normals:
             return normals
 
         split_normals = [Vector() for _ in normals]
         split_normal_count = [0] * len(normals)
 
-        mesh.calc_normals_split()
         for loop, normal in zip(mesh.loops, mesh.corner_normals):
             split_normals[loop.vertex_index] += normal.vector
             split_normal_count[loop.vertex_index] += 1

--- a/blender/source/importing/i_mesh.py
+++ b/blender/source/importing/i_mesh.py
@@ -207,8 +207,6 @@ class MeshProcessor:
 
     def _setup_mesh_normals(self):
         self.output.mesh.normals_split_custom_set_from_vertices(self.normals)
-        self.output.mesh.use_auto_smooth = True
-        self.output.mesh.auto_smooth_angle = 180
 
     def _setup_mesh_colors(self):
         if self.weighted_buffer.HasColors:

--- a/blender/source/importing/i_node.py
+++ b/blender/source/importing/i_node.py
@@ -1,7 +1,7 @@
 import bpy
 from mathutils import Matrix, Vector, Quaternion
 
-from . import i_enum, i_matrix, i_mesh
+from . import i_enum, i_matrix, i_mesh, i_texture
 from ..exceptions import SAIOException
 
 class NodeProcessor:
@@ -396,10 +396,18 @@ class NodeProcessor:
         nodes = import_data.Root.GetTreeNodes()
         if force_armature or import_data.Weighted:
             self.process_as_armature(nodes, name)
-            return self._armature_obj
+            result = self._armature_obj
         else:
             self.process_as_objects(nodes)
-            return self.object_map[nodes[0]]
+            result = self.object_map[nodes[0]]
+
+        if import_data.TextureNames is not None:
+            result.saio_texturename_world = bpy.data.worlds.new(name + "_tex")
+            i_texture.process_texture_names(
+                import_data.TextureNames,
+                result.saio_texturename_world.saio_texturename_list)
+
+        return result
 
 
     def setup_materials(self):

--- a/blender/source/register/operators/anim_import_operators.py
+++ b/blender/source/register/operators/anim_import_operators.py
@@ -12,7 +12,6 @@ from .base import SAIOBaseFileLoadOperator
 from ...dotnet import load_dotnet, SA3D_Modeling
 from ...utility import bone_utils, camera_utils
 from ...utility.general import target_anim_editor
-from ...utility.draw import expand_menu
 from ...importing import i_motion
 
 
@@ -89,8 +88,9 @@ class SAIO_OT_Import_Node_Animation(MotionImportOperator):
         layout = self.layout
         layout.prop(self, "rotation_mode")
 
-        box = layout.box()
-        if expand_menu(box, self, "show_advanced"):
+        header, box = layout.panel("saio_ot_ina_advanced", default_closed=True)
+        header.label(text="Advanced")
+        if box:
             box.prop(self, "quaternion_threshold")
             box.prop(self, "short_rot")
 

--- a/blender/source/register/operators/base_export_operators.py
+++ b/blender/source/register/operators/base_export_operators.py
@@ -6,7 +6,6 @@ from bpy.props import (
     StringProperty
 )
 from .base import SAIOBaseFileSaveOperator
-from ...utility.draw import expand_menu
 from ...utility.anim_parameters import AnimParameters
 
 class ExportOperator(SAIOBaseFileSaveOperator):
@@ -171,11 +170,6 @@ class AnimationExportOperator(ExportOperator):
         default=0
     )
 
-    show_advanced: BoolProperty(
-        name="Advanced",
-        default=False
-    )
-
     def get_anim_parameters(self):
         return AnimParameters(
             True,
@@ -187,8 +181,9 @@ class AnimationExportOperator(ExportOperator):
         )
 
     def draw(self, context: bpy.types.Context):
-        box = self.layout.box()
-        if expand_menu(box, self, "show_advanced"):
+        header, box = self.layout.panel("saio_ot_ae_advanced", default_closed=True)
+        header.label(text="Advanced")
+        if box:
             box.prop(self, "interpolation_threshold")
             box.prop(self, "general_optimization_threshold")
 
@@ -295,8 +290,10 @@ class NodeAnimExportOperator(AnimationExportOperator):
             layout.prop(self, "force_sort_bones")
         layout.prop(self, "short_rot")
         layout.prop(self, "ensure_positive_euler_angles")
-        box = layout.box()
-        if expand_menu(box, self, "show_advanced"):
+
+        header, box = layout.panel("saio_ot_nae_advanced", default_closed=True)
+        header.label(text="Advanced")
+        if box:
             box.prop(self, "rotation_mode")
             box.prop(self, "interpolation_threshold")
             box.prop(self, "quaternion_threshold")

--- a/blender/source/register/operators/export_operators.py
+++ b/blender/source/register/operators/export_operators.py
@@ -13,7 +13,6 @@ from .base_export_operators import (
 )
 
 from ...utility.anim_parameters import AnimParameters
-from ...utility.draw import expand_menu
 from ...dotnet import SA3D_Modeling
 
 
@@ -297,15 +296,16 @@ class ExportLVLOperator(ExportModelOperator):
         layout.prop(self, "fallback_surface_attributes")
         self.draw_insert()
 
-        box = layout.box()
-        if expand_menu(box, self, "show_animation"):
-
+        header, box = layout.panel("saio_ot_lvle_animation", default_closed=True)
+        header.label(text="Animation")
+        if box:
             box.prop(self, "auto_root")
             box.prop(self, "force_sort_bones")
             box.prop(self, "short_rot")
 
-            box2 = box.box()
-            if expand_menu(box2, self, "show_advanced"):
+            header2, box2 = box.panel("saio_ot_lvle_advanced", default_closed=True)
+            header2.label(text="Advanced")
+            if box2:
                 box2.prop(self, "rotation_mode")
                 box2.prop(self, "interpolation_threshold")
                 box2.prop(self, "quaternion_threshold")

--- a/blender/source/register/operators/import_operators.py
+++ b/blender/source/register/operators/import_operators.py
@@ -12,7 +12,6 @@ from bpy.types import Context
 from .base import SAIOBaseFileLoadOperator
 
 from ...dotnet import load_dotnet, SAIO_NET
-from ...utility.draw import expand_menu
 
 
 class ModelImportOperator(SAIOBaseFileLoadOperator):
@@ -221,8 +220,9 @@ class SAIO_OT_Import_Landtable(ModelImportOperator):
         layout.prop(self, "fix_view")
         layout.prop(self, "ensure_static_order")
 
-        box = layout.box()
-        if expand_menu(box, self, "show_anim"):
+        header, box = layout.panel("saio_ot_lvli_animation", default_closed=True)
+        header.label(text="Animation")
+        if box:
             box.prop(self, "all_weighted_meshes")
             box.prop(self, "merge_meshes")
             box.prop(self, "ensure_order")
@@ -231,8 +231,9 @@ class SAIO_OT_Import_Landtable(ModelImportOperator):
 
             box.prop(self, "rotation_mode")
 
-            box2 = box.box()
-            if expand_menu(box2, self, "show_advanced_anim"):
+            header2, box2 = box.panel("saio_ot_lvli_advanced", default_closed=True)
+            header2.label(text="Advanced")
+            if box2:
                 box2.prop(self, "quaternion_threshold")
                 box2.prop(self, "short_rot")
 

--- a/blender/source/register/operators/tool_operators.py
+++ b/blender/source/register/operators/tool_operators.py
@@ -12,7 +12,6 @@ from .anim_export_operators import SAIO_OT_Export_Node_Animation
 
 from ..property_groups.node_properties import SAIO_Node
 
-from ...utility.draw import expand_menu
 from ...utility.general import target_anim_editor
 from ...exceptions import SAIOException
 from ...dotnet import load_dotnet, TextCopy
@@ -130,11 +129,6 @@ class SAIO_OT_TestBakeAnimation(SAIOBaseOperator):
         default=0.01
     )
 
-    out_show_advanced: BoolProperty(
-        name="Advanced",
-        default=False
-    )
-
     in_rotation_mode: EnumProperty(
         name="Rotation Mode",
         description="How rotations should be imported",
@@ -163,10 +157,6 @@ class SAIO_OT_TestBakeAnimation(SAIOBaseOperator):
         max=1
     )
 
-    in_show_advanced: BoolProperty(
-        name="Advanced",
-        default=False
-    )
 
     @classmethod
     def poll(cls, context):
@@ -180,8 +170,9 @@ class SAIO_OT_TestBakeAnimation(SAIOBaseOperator):
         layout.prop(self, "out_short_rot")
         layout.prop(self, "out_ensure_positive_euler_angles")
 
-        box = layout.box()
-        if expand_menu(box, self, "out_show_advanced"):
+        header, box = layout.panel("saio_ot_tba_out_advanced", default_closed=True)
+        header.label(text="Advanced")
+        if box:
             box.prop(self, "out_rotation_mode")
             box.prop(self, "out_interpolation_threshold")
             box.prop(self, "out_quaternion_threshold")
@@ -193,8 +184,9 @@ class SAIO_OT_TestBakeAnimation(SAIOBaseOperator):
 
         layout.prop(self, "in_rotation_mode")
 
-        box = layout.box()
-        if expand_menu(box, self, "in_show_advanced"):
+        header, box = layout.panel("saio_ot_tba_in_advanced", default_closed=True)
+        header.label(text="Advanced")
+        if box:
             box.prop(self, "in_quaternion_threshold")
 
     def _execute(self, context: bpy.types.Context):

--- a/blender/source/register/property_groups/panel_properties.py
+++ b/blender/source/register/property_groups/panel_properties.py
@@ -8,34 +8,7 @@ from bpy.props import (
 class SAIO_PanelSettings(bpy.types.PropertyGroup):
     """Property Group for managing expanded menus"""
 
-    # === Material ===
-
-    expanded_texture_properties: BoolProperty(
-        name="Texture properties",
-        default=False
-    )
-
-    expanded_rendering_properties: BoolProperty(
-        name="Rendering properties",
-        default=False
-    )
-
-    expanded_gc_properties: BoolProperty(
-        name="SA2B specific",
-        default=False
-    )
-
-    expanded_gc_texgen: BoolProperty(
-        name="Generate texture coords",
-        default=False
-    )
-
     # === Land Entry ===
-
-    expanded_surface_attributes: BoolProperty(
-        name="Surface Attributes",
-        default=False
-    )
 
     advanced_surface_attributes: BoolProperty(
         name="Advanced Surface Attributes",
@@ -63,11 +36,6 @@ class SAIO_PanelSettings(bpy.types.PropertyGroup):
     )
 
     # == Event ==
-
-    expanded_override_upgrade_menu: BoolProperty(
-        name="Integrated Upgrades",
-        default=False
-    )
 
     override_upgrade_menu: EnumProperty(
         name="Upgrade",
@@ -111,11 +79,6 @@ class SAIO_PanelSettings(bpy.types.PropertyGroup):
         default="SONLS"
     )
 
-    expanded_attach_upgrade_menu: BoolProperty(
-        name="Overlay Upgrades",
-        default=False
-    )
-
     attach_upgrade_menu: EnumProperty(
         name="Upgrade",
         items=[
@@ -143,16 +106,4 @@ class SAIO_PanelSettings(bpy.types.PropertyGroup):
             ("EGGWS", "Eggman Windshield (Transparency)", ""),
         ],
         default="SONLS"
-    )
-
-    expanded_uv_animations_menu: BoolProperty(
-        name="UV Animations",
-        default=False
-    )
-
-    # === Scene ===
-
-    expanded_lighting_panel: BoolProperty(
-        name="Lighting Data",
-        default=False
     )

--- a/blender/source/register/ui/event_panel.py
+++ b/blender/source/register/ui/event_panel.py
@@ -8,8 +8,6 @@ from ..property_groups.event_properties import SAIO_Event
 from ..property_groups.panel_properties import SAIO_PanelSettings
 from ..operators import event_operators as eveop
 
-from ...utility.draw import expand_menu
-
 EVENTLIST_TOOLS = [
     (
         eveop.SAIO_OT_EventScene_Add.bl_idname,
@@ -211,25 +209,25 @@ class SAIO_PT_Event(PropertiesPanel):
         SAIO_PT_Event.draw_object_bone(
             box, event_properties, "tails_tails")
 
-        box = layout.box()
-        if expand_menu(box, panel_properties,
-                       "expanded_override_upgrade_menu"):
-
+        header, box = layout.panel("saio_scene_override_upgrades", default_closed=True)
+        header.label(text="Integrated Upgrades")
+        if box:
             SAIO_PT_Event.draw_override_upgrade_menu(
                 box,
                 event_properties,
                 panel_properties)
 
-        box = layout.box()
-        if expand_menu(box, panel_properties, "expanded_attach_upgrade_menu"):
-
+        header, box = layout.panel("saio_scene_attach_upgrades", default_closed=True)
+        header.label(text="Overlay Upgrades")
+        if box:
             SAIO_PT_Event.draw_attach_upgrade_menu(
                 box,
                 event_properties,
                 panel_properties)
 
-        box = layout.box()
-        if expand_menu(box, panel_properties, "expanded_uv_animations_menu"):
+        header, box = layout.panel("saio_scene_tex_anim", default_closed=True)
+        header.label(text="Texture animations")
+        if box:
             draw_event_uv_anim_list(box, event_properties.uv_animations)
 
     # === Overriden methods ===

--- a/blender/source/register/ui/land_entry_panel.py
+++ b/blender/source/register/ui/land_entry_panel.py
@@ -6,7 +6,7 @@ from ..property_groups.scene_properties import SAIO_Scene
 from ..property_groups.land_entry_properties import SAIO_LandEntry
 from ..property_groups.panel_properties import SAIO_PanelSettings
 
-from ...utility.draw import prop_advanced, expand_menu
+from ...utility.draw import prop_advanced
 
 
 LAND_ENTRY_ATTRIBUTE_LISTS = {
@@ -159,8 +159,9 @@ class SAIO_PT_LandEntry(PropertiesPanel):
             panel_settings: SAIO_PanelSettings,
             draw_unknown: bool):
 
-        box = layout.box()
-        if not expand_menu(box, panel_settings, "expanded_surface_attributes"):
+        header, box = layout.panel("saio_obj_surface", default_closed=True)
+        header.label(text="Surface attributes")
+        if not box:
             return
 
         attribute_list = LAND_ENTRY_ATTRIBUTE_LISTS[

--- a/blender/source/register/ui/material_mass_edit_panel.py
+++ b/blender/source/register/ui/material_mass_edit_panel.py
@@ -45,7 +45,6 @@ class SAIO_PT_MaterialMassEdit(viewport_toolbar.ViewportToolPanel):
             self.layout.box(),
             None,
             mass_edit_properties.material_properties,
-            mass_edit_properties.panels,
             mass_edit_properties,
             False,
             False)

--- a/blender/source/register/ui/material_panel.py
+++ b/blender/source/register/ui/material_panel.py
@@ -4,7 +4,6 @@ from bpy.types import Context
 from .base_panel import PropertiesPanel
 
 from ..property_groups.material_properties import SAIO_Material
-from ..property_groups.panel_properties import SAIO_PanelSettings
 from ..property_groups.material_mass_edit_properties import (
     SAIO_MaterialMassEdit
 )
@@ -12,7 +11,7 @@ from ..operators.material_operators import (
     SAIO_OT_Material_UpdateActiveProperties
 )
 
-from ...utility.draw import prop_advanced, expand_menu
+from ...utility.draw import prop_advanced
 
 
 class SAIO_PT_Material(PropertiesPanel):
@@ -24,15 +23,12 @@ class SAIO_PT_Material(PropertiesPanel):
             layout: bpy.types.UILayout,
             material: bpy.types.Material,
             material_properties: bpy.types.Material,
-            panel_settings: SAIO_PanelSettings,
             mass_edit_properties: SAIO_MaterialMassEdit = None,
             darken_panels=True):
 
-        texture_menu = layout.box()
-        if not expand_menu(
-                texture_menu,
-                panel_settings,
-                "expanded_texture_properties"):
+        header, texture_menu = layout.panel("saio_mat_texture", default_closed=True)
+        header.label(text="Texture properties")
+        if not texture_menu:
             return
 
         texture_menu.prop(
@@ -100,15 +96,12 @@ class SAIO_PT_Material(PropertiesPanel):
     def draw_rendering_properties(
             layout: bpy.types.UILayout,
             material_properties: SAIO_Material,
-            panel_settings: SAIO_PanelSettings,
             mass_edit_properties: SAIO_MaterialMassEdit = None,
             darken_panels=True):
 
-        rendering_menu = layout.box()
-        if not expand_menu(
-                rendering_menu,
-                panel_settings,
-                "expanded_rendering_properties"):
+        header, rendering_menu = layout.panel("saio_mat_rendering", default_closed=True)
+        header.label(text="Rendering properties")
+        if not rendering_menu:
             return
 
         def rendering_prop(label, name):
@@ -153,14 +146,11 @@ class SAIO_PT_Material(PropertiesPanel):
     def draw_gc_properties(
             layout: bpy.types.UILayout,
             material_properties: SAIO_Material,
-            panel_settings: SAIO_PanelSettings,
             quick_edit_properties: SAIO_MaterialMassEdit = None):
 
-        gc_menu = layout.box()
-        if not expand_menu(
-                gc_menu,
-                panel_settings,
-                "expanded_gc_properties"):
+        header, gc_menu = layout.panel("saio_mat_gc", default_closed=True)
+        header.label(text="SA2B specific")
+        if not gc_menu:
             return
 
         def gc_prop(label, name, qe_name):
@@ -190,7 +180,6 @@ class SAIO_PT_Material(PropertiesPanel):
             layout: bpy.types.UILayout,
             material: bpy.types.Material,
             material_properties: bpy.types.Material,
-            panel_settings: SAIO_PanelSettings,
             mass_edit_properties: SAIO_MaterialMassEdit = None,
             darken_panels=True,
             show_operator=True):
@@ -217,21 +206,18 @@ class SAIO_PT_Material(PropertiesPanel):
             layout,
             material,
             material_properties,
-            panel_settings,
             mass_edit_properties,
             darken_panels)
 
         SAIO_PT_Material.draw_rendering_properties(
             layout,
             material_properties,
-            panel_settings,
             mass_edit_properties,
             darken_panels)
 
         SAIO_PT_Material.draw_gc_properties(
             layout,
             material_properties,
-            panel_settings,
             mass_edit_properties)
 
     # === overriden methods === #
@@ -259,5 +245,4 @@ class SAIO_PT_Material(PropertiesPanel):
         SAIO_PT_Material.draw_material_properties(
             self.layout,
             context.active_object.active_material,
-            context.active_object.active_material.saio_material,
-            context.scene.saio_scene.panels)
+            context.active_object.active_material.saio_material)

--- a/blender/source/register/ui/scene_panel.py
+++ b/blender/source/register/ui/scene_panel.py
@@ -1,8 +1,7 @@
 import bpy
 from .base_panel import PropertiesPanel
-from ..property_groups.panel_properties import SAIO_PanelSettings
 from ..property_groups.scene_properties import SAIO_Scene
-from ...utility.draw import prop_advanced, expand_menu
+from ...utility.draw import prop_advanced
 
 
 class SAIO_PT_Scene(PropertiesPanel):
@@ -12,26 +11,23 @@ class SAIO_PT_Scene(PropertiesPanel):
     @staticmethod
     def draw_lighting_panel(
             layout: bpy.types.UILayout,
-            setting_properties: SAIO_Scene,
-            panel_settings: SAIO_PanelSettings):
+            setting_properties: SAIO_Scene):
 
-        box = layout.box()
-        if not expand_menu(
-                box,
-                panel_settings,
-                "expanded_lighting_panel"):
+        header, panel = layout.panel("saio_scene_lighting", default_closed=True)
+        header.label(text="Lighting Data")
+        if not panel:
             return
 
         def lighting_prop(label, name):
-            prop_advanced(box, label, setting_properties, name)
+            prop_advanced(panel, label, setting_properties, name)
 
         lighting_prop("Light Direction", "light_dir")
         lighting_prop("Light Color", "light_color")
         lighting_prop("Ambient Color", "light_ambient_color")
 
-        box.separator()
+        panel.separator()
 
-        box.prop(setting_properties, "display_specular")
+        panel.prop(setting_properties, "display_specular")
         lighting_prop("Viewport blend mode", "viewport_alpha_type")
         if setting_properties.viewport_alpha_type == 'CLIP':
             lighting_prop("Viewport blend cutoff", "viewport_alpha_cutoff")
@@ -40,8 +36,7 @@ class SAIO_PT_Scene(PropertiesPanel):
     @staticmethod
     def draw_scene_properties(
             layout: bpy.types.UILayout,
-            scene: bpy.types.Scene,
-            panel_settings: SAIO_PanelSettings):
+            scene: bpy.types.Scene):
         setting_properties: SAIO_Scene = scene.saio_scene
 
         layout.prop(setting_properties, "author")
@@ -51,12 +46,10 @@ class SAIO_PT_Scene(PropertiesPanel):
 
         SAIO_PT_Scene.draw_lighting_panel(
             layout,
-            setting_properties,
-            panel_settings
+            setting_properties
         )
 
     def draw_panel(self, context):
         SAIO_PT_Scene.draw_scene_properties(
             self.layout,
-            context.scene,
-            context.scene.saio_scene.panels)
+            context.scene)

--- a/blender/source/utility/draw.py
+++ b/blender/source/utility/draw.py
@@ -31,30 +31,6 @@ def prop_advanced(
         row.prop(prop1, prop1Name, text="")
 
 
-def expand_icon(value):
-    if value:
-        return "TRIA_DOWN"
-    else:
-        return "TRIA_RIGHT"
-
-
-def expand_menu(
-        layout: bpy.types.UILayout,
-        prop: any,
-        name: str):
-
-    opened = getattr(prop, name)
-
-    layout.prop(
-        prop,
-        name,
-        icon=expand_icon(opened),
-        emboss=False
-    )
-
-    return getattr(prop, name)
-
-
 TOOL_PROPERTY = tuple[str, str, dict]
 
 

--- a/blender/source/utility/texture_manager.py
+++ b/blender/source/utility/texture_manager.py
@@ -71,7 +71,7 @@ class TexlistManager:
 
     _compiled_tex_lists: dict[SAIO_TextureList, CompiledTexlist]
     _texname_strings: dict[SAIO_TextureNameList, str]
-    _compiled_tex_name_lists: dict[str, CompiledTexlist]
+    _compiled_tex_name_lists: dict[SAIO_TextureList, dict[str, CompiledTexlist]]
 
     _list_mapping: dict[CompiledTexlist, set[bpy.types.Material]]
     _material_mapping: dict[bpy.types.Material, CompiledTexlist]
@@ -101,7 +101,6 @@ class TexlistManager:
                 compiled_list = self._compiled_tex_lists[texture_list]
 
         else:
-
             # getting the texname string
             if texture_names not in self._texname_strings:
                 texname_string = ""
@@ -182,6 +181,17 @@ class TexlistManager:
         self._root_texlist = self._get_compiled_tex_list(
             texture_list, texture_names)
 
+        parentless = set()
+
+        for obj in scene.objects:
+            target = obj
+            while target.parent is not None:
+                target = target.parent
+            parentless.add(target)
+
+        for obj in parentless:
+            self._eval_obj_materials(obj, texture_list, texture_names, self._root_texlist)
+
         all_materials = set()
         for material_list in self._list_mapping.values():
             all_materials.update(material_list)
@@ -189,7 +199,7 @@ class TexlistManager:
         for material in all_materials:
             compiled_list = None
             for key, material_list in self._list_mapping.items():
-                if material not in material_list:
+                if material in material_list:
                     if compiled_list is not None:
                         compiled_list = self._root_texlist
                         break

--- a/documentation/docs/guides/installation.md
+++ b/documentation/docs/guides/installation.md
@@ -34,7 +34,7 @@ For more information on the toolset, visit [the wiki](https://github.com/X-Hax/s
 
 ## Installing Blender
 
-The Addon is only supported on versions of [Blender](https://blender.org) 3.6 and above.
+The Addon is only supported on versions of [Blender](https://blender.org) 4.1 and above.
 <br/> A recommendation is to get Blender through [**Steam**](https://store.steampowered.com/app/365670). This will ensure you're always on the latest release version.
 
 ## Installing the Addon

--- a/dotnet/Cutscene.cs
+++ b/dotnet/Cutscene.cs
@@ -153,7 +153,7 @@ namespace SAIO.NET
             List<Model> models = new();
             foreach(Node node in nodes)
             {
-                models.Add(Model.Process(node, optimize));
+                models.Add(Model.Process(node, null, optimize));
             }
 
             // compare texture list with texture names

--- a/dotnet/Model.cs
+++ b/dotnet/Model.cs
@@ -5,6 +5,7 @@ using SA3D.Modeling.Mesh.Weighted;
 using SA3D.Modeling.ObjectData;
 using SA3D.Modeling.ObjectData.Enums;
 using SA3D.Modeling.Structs;
+using SA3D.Texturing.Texname;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -15,17 +16,19 @@ namespace SAIO.NET
     {
         public Node Root { get; }
         public WeightedMesh[] Attaches { get; }
+        public TextureNameList? TextureNames { get; }
         public bool Weighted { get; }
         public string Author { get; }
         public string Description { get; }
 
-        public Model(Node root, WeightedMesh[] attaches, bool weighted, string author, string description)
+        public Model(Node root, WeightedMesh[] attaches, TextureNameList? textureNames, bool weighted, string author, string description)
         {
             Root = root;
             Attaches = attaches;
             Weighted = weighted;
             Author = author;
             Description = description;
+            TextureNames = textureNames;
         }
 
         public static Node ToNodeStructure(
@@ -123,10 +126,10 @@ namespace SAIO.NET
         public static Model Import(string filepath, bool optimize, bool flipVertexColors)
         {
             ModelFile file = ModelFile.ReadFromFile(filepath);
-            return Process(file.Model, optimize, flipVertexColors, file.MetaData.Author ?? string.Empty, file.MetaData.Description ?? string.Empty);
+            return Process(file.Model, file.TextureNames, optimize, flipVertexColors, file.MetaData.Author ?? string.Empty, file.MetaData.Description ?? string.Empty);
         }
 
-        public static Model Process(Node node, bool optimize, bool flipVertexColors = false, string author = "", string desription = "")
+        public static Model Process(Node node, TextureNameList? textureNames, bool optimize, bool flipVertexColors = false, string author = "", string desription = "")
         {
             node.BufferMeshData(optimize);
             WeightedMesh[] meshes = WeightedMesh.FromModel(node, BufferMode.None);
@@ -161,7 +164,7 @@ namespace SAIO.NET
                 }
             }
 
-            return new Model(node, meshes, weighted, author, desription);
+            return new Model(node, meshes, textureNames, weighted, author, desription);
         }
     }
 }

--- a/dotnet/SAIO.NET.csproj
+++ b/dotnet/SAIO.NET.csproj
@@ -13,9 +13,9 @@
 	<ItemGroup>
 		<PackageReference Include="TextCopy" Version="6.2.1" />
 		<PackageReference Include="SA3D.Common" Version="1.4.6" />
-		<PackageReference Include="SA3D.Texturing" Version="1.3.6" />
-		<PackageReference Include="SA3D.Archival" Version="1.1.1" />
-		<PackageReference Include="SA3D.Modeling" Version="1.1.2" />
+		<PackageReference Include="SA3D.Texturing" Version="1.3.7" />
+		<PackageReference Include="SA3D.Archival" Version="1.1.2" />
+		<PackageReference Include="SA3D.Modeling" Version="1.1.5" />
 		<PackageReference Include="SA3D.Modeling.JSON" Version="1.0.1" />
 		<PackageReference Include="SA3D.SA2Event" Version="1.0.3" />
 	</ItemGroup>

--- a/dotnet/SAIO.NET.csproj
+++ b/dotnet/SAIO.NET.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="TextCopy" Version="6.2.1" />
-		<PackageReference Include="SA3D.Common" Version="1.4.6" />
+		<PackageReference Include="SA3D.Common" Version="1.4.7" />
 		<PackageReference Include="SA3D.Texturing" Version="1.3.7" />
 		<PackageReference Include="SA3D.Archival" Version="1.1.2" />
 		<PackageReference Include="SA3D.Modeling" Version="1.1.5" />


### PR DESCRIPTION
## Fixed issues
- Blender 4.1 breaking changes (#12)
- Processing materials on welded BASIC broken
- Texture list evaluation not working for object-specific texture- and texturename-lists
- NJ files with multiple blocks throw exception
- Animations of NSSM and NCAM types not recognized
- NJ animations only reading with 16 bit rotations
- Exporting or importing of PAK archives with long names can break
- Texcoord precision on SA2B models completely broken on import and export
- BASIC models with NULL normals cannot be read

## Additions
- Panels now use new blender API dedicated for panels
- Texturename lists in NJ model files now get imported